### PR TITLE
refactor: refactor validator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.21
 require (
 	github.com/abcxyz/jvs v0.1.4
 	github.com/abcxyz/pkg v0.7.1
+	github.com/google/go-cmp v0.6.0
 	github.com/google/go-github/v55 v55.0.0
 )
 
@@ -15,7 +16,6 @@ require (
 	github.com/fatih/color v1.15.0 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/hashicorp/go-hclog v1.5.0 // indirect
 	github.com/hashicorp/go-plugin v1.5.2 // indirect

--- a/pkg/plugin/errors.go
+++ b/pkg/plugin/errors.go
@@ -14,6 +14,10 @@
 
 package plugin
 
-import "fmt"
+type invalidJustificationError string
 
-var errInvalidJustification = fmt.Errorf("invalid justification")
+func (e invalidJustificationError) Error() string {
+	return string(e)
+}
+
+const errInvalidJustification = invalidJustificationError("invalid justification")

--- a/pkg/plugin/errors.go
+++ b/pkg/plugin/errors.go
@@ -14,10 +14,10 @@
 
 package plugin
 
-type invalidJustificationError string
+type Error string
 
-func (e invalidJustificationError) Error() string {
+func (e Error) Error() string {
 	return string(e)
 }
 
-const errInvalidJustification = invalidJustificationError("invalid justification")
+const errInvalidJustification = Error("invalid justification")

--- a/pkg/plugin/validator.go
+++ b/pkg/plugin/validator.go
@@ -17,7 +17,6 @@ package plugin
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -65,7 +64,7 @@ func NewValidator(ghClinet *github.Client, ghApp *githubapp.GitHubApp) *Validato
 func (v *Validator) MatchIssue(ctx context.Context, issueURL string) (*pluginGitHubIssue, error) {
 	info, err := parseIssueInfoFromURL(issueURL)
 	if err != nil {
-		return nil, errors.Join(errInvalidJustification, fmt.Errorf("failed to parse issueURL: %w", err))
+		return nil, fmt.Errorf("%w: failed to parse issueURL: %w", errInvalidJustification, err)
 	}
 
 	t, err := v.getAccessToken(ctx, info.RepoName)
@@ -86,12 +85,12 @@ func (v *Validator) validateIssue(ctx context.Context, pi *pluginGitHubIssue) er
 		//
 		// See: https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28#get-an-issue--status-codes.
 		if resp.StatusCode == http.StatusNotFound {
-			return errors.Join(errInvalidJustification, fmt.Errorf("issue not found: %w", err))
+			return fmt.Errorf("%w: issue not found: %w", errInvalidJustification, err)
 		}
 		return fmt.Errorf("failed to get issue info: %w", err)
 	}
 	if s := issue.GetState(); s != "open" {
-		return errors.Join(errInvalidJustification, fmt.Errorf("issue is in state: %s, please make sure to use an open issue", s))
+		return fmt.Errorf("%w: issue is in state: %s, please make sure to use an open issue", errInvalidJustification, s)
 	}
 	return nil
 }

--- a/pkg/plugin/validator.go
+++ b/pkg/plugin/validator.go
@@ -47,7 +47,7 @@ type ExchangeResponse struct {
 
 // pluginGithubIssue contains the required attribute parsed from
 // the issue URL.
-type pluginGithubIssue struct {
+type pluginGitHubIssue struct {
 	Owner       string
 	RepoName    string
 	IssueNumber int
@@ -62,26 +62,26 @@ func NewValidator(ghClinet *github.Client, ghApp *githubapp.GitHubApp) *Validato
 }
 
 // MatchIssue parses issue info from provided issueURL and validate if the issue is valid.
-func (v *Validator) MatchIssue(ctx context.Context, issueURL string) error {
+func (v *Validator) MatchIssue(ctx context.Context, issueURL string) (*pluginGitHubIssue, error) {
 	info, err := parseIssueInfoFromURL(issueURL)
 	if err != nil {
-		return errors.Join(errInvalidJustification, fmt.Errorf("failed to parse issueURL: %w", err))
+		return nil, errors.Join(errInvalidJustification, fmt.Errorf("failed to parse issueURL: %w", err))
 	}
 
 	t, err := v.getAccessToken(ctx, info.RepoName)
 	if err != nil {
-		return fmt.Errorf("failed to get access token: %w", err)
+		return nil, fmt.Errorf("failed to get access token: %w", err)
 	}
 	v.client = v.client.WithAuthToken(t)
 
-	return v.validateIssue(ctx, info)
+	return info, v.validateIssue(ctx, info)
 }
 
 // validateIssue verifies if the issue exists and the issue is open.
-func (v *Validator) validateIssue(ctx context.Context, pi *pluginGithubIssue) error {
+func (v *Validator) validateIssue(ctx context.Context, pi *pluginGitHubIssue) error {
 	issue, resp, err := v.client.Issues.Get(ctx, pi.Owner, pi.RepoName, pi.IssueNumber)
 	if err != nil {
-		// when the issue doesn't not exist, github rest api will return a 404
+		// When the issue doesn't not exist, github rest api will return a 404
 		// all other non-200 status code will be treated as internal error.
 		//
 		// See: https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28#get-an-issue--status-codes.
@@ -119,7 +119,7 @@ func (v *Validator) getAccessToken(ctx context.Context, repoName string) (string
 }
 
 // parseGithubIssue parses issue info from Issue URL.
-func parseIssueInfoFromURL(issueURL string) (*pluginGithubIssue, error) {
+func parseIssueInfoFromURL(issueURL string) (*pluginGitHubIssue, error) {
 	if match, _ := regexp.MatchString(issueURLPatternRegExp, issueURL); !match {
 		return nil, fmt.Errorf("invalid issue url, issueURL doesn't match pattern: %s", issueURLPatternRegExp)
 	}
@@ -135,7 +135,7 @@ func parseIssueInfoFromURL(issueURL string) (*pluginGithubIssue, error) {
 		return nil, fmt.Errorf("failed to convert issueNumber %s to int: %w", arr[4], err)
 	}
 
-	return &pluginGithubIssue{
+	return &pluginGitHubIssue{
 		Owner:       arr[1],
 		RepoName:    arr[2],
 		IssueNumber: issueNumber,


### PR DESCRIPTION
This PR does three things:
1. Refactor Validator's `MatchIssue()`, to return the parsed `pluginGithubIssue`, so we are able to 
  - Test `parseIssueInfoFromURL` is doing as expected. 
  - Enable `plugin.go` to use the issue info to fill in the `annotation field` for `jvspb.ValidateJustificationResponse`, see example here: https://github.com/abcxyz/jvs-plugin-github/blob/sailorlqh/imple_plugin/pkg/plugin/plugin.go#L79-L83.

2. Refactor errors, and make `errInvalidJustification` a const as suggested here: https://dave.cheney.net/2016/04/07/constant-errors

3. Some chore like variable naming, comment linting etc.