### PR TITLE
fix: change varible type from list to map

### DIFF
--- a/terraform/modules/secret_manager/main.tf
+++ b/terraform/modules/secret_manager/main.tf
@@ -61,11 +61,11 @@ resource "google_secret_manager_secret_version" "gh_app_private_key_version" {
 // grant service account to access the secret, so the services can use that
 // for auth with github.
 resource "google_secret_manager_secret_iam_member" "gh_app_pk_accessor" {
-  for_each = toset(var.gh_pk_accessor_members)
+  for_each = var.gh_pk_accessor_members_map
 
   project = var.project_id
 
   secret_id = google_secret_manager_secret.gh_app_private_key.id
   role      = "roles/secretmanager.secretAccessor"
-  member    = each.key
+  member    = each.value
 }

--- a/terraform/modules/secret_manager/variables.tf
+++ b/terraform/modules/secret_manager/variables.tf
@@ -23,13 +23,15 @@ variable "labels" {
   default     = {}
 }
 
-variable "gh_pk_accessor_members" {
+variable "gh_pk_accessor_members_map" {
   description = <<EOT
-    The service accounts that need roles/secretmanager.secretAccessor role 
-    for accessing keys stored in secret manager. Normally it will be jvs's
-    api and ui service account.
+    The value of each entry in the map will be the service account that need
+    roles/secretmanager.secretAccessor role for accessing keys stored in secret manager.
+     Normally it will be jvs's api and ui service account.
+    This is a map so when terraform won't complain when values are derived from resource
+    attributes that cannot be determined until apply.
   EOT
-  type = list(string)
+  type = map(string)
 }
 
 variable "gh_private_key_secret_id" {


### PR DESCRIPTION
Using this as a map can solve the terraform problem when we are getting attributes from some module that are only known after apply, and use them in other modules.

This way, we can directly use the output for jvs module to grand the permission. The example code for deploying is like: https://github.com/abcxyz/infra-gcp/pull/624/files#diff-c1dc57438c05cd1ff18d3b63b6aa8c14b1bd0585e1cbb01efd53e5fff02a7a07R77-R88