### PR TITLE
Remove shadowed loop variables

### DIFF
--- a/pkg/cli/server_test.go
+++ b/pkg/cli/server_test.go
@@ -102,8 +102,6 @@ func TestServerCommand(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/plugin/config_test.go
+++ b/pkg/plugin/config_test.go
@@ -80,8 +80,6 @@ func TestPluginConfig_ToFlags(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -176,14 +174,12 @@ func TestPluginConfig_Validate(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			err := tc.cfg.Validate()
 			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
-				t.Errorf(diff)
+				t.Error(diff)
 			}
 		})
 	}

--- a/pkg/plugin/keyutil/pem_test.go
+++ b/pkg/plugin/keyutil/pem_test.go
@@ -47,15 +47,13 @@ func TestReadRSAPrivateKey(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			gotPK, err := ReadRSAPrivateKey(tc.pkPEMString)
 
 			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
-				t.Errorf(diff)
+				t.Error(diff)
 			}
 			// if gotPK and wantPK are both nil, no check is needed.
 			if !(gotPK == nil && tc.wantPK == nil) {

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -74,7 +74,7 @@ func (g *GitHubPlugin) Validate(ctx context.Context, req *jvspb.ValidateJustific
 		if errors.Is(err, errInvalidJustification) {
 			return generateInvalidErrResq(err.Error()), nil
 		} else {
-			return nil, status.Errorf(codes.Internal, err.Error())
+			return nil, status.Error(codes.Internal, err.Error())
 		}
 	}
 	return &jvspb.ValidateJustificationResponse{

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -127,7 +127,6 @@ func TestValidate(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		ctx := context.Background()
 
 		t.Run(tc.name, func(t *testing.T) {
@@ -138,7 +137,7 @@ func TestValidate(t *testing.T) {
 			}
 			gotResq, gotErr := p.Validate(ctx, tc.req)
 			if diff := testutil.DiffErrString(gotErr, tc.wantErr); diff != "" {
-				t.Errorf(diff)
+				t.Error(diff)
 			}
 			if diff := cmp.Diff(tc.wantResq, gotResq, cmpopts.IgnoreUnexported(jvspb.ValidateJustificationResponse{})); diff != "" {
 				t.Errorf("Failed validation (-want,+got):\n%s", diff)

--- a/pkg/plugin/validator_test.go
+++ b/pkg/plugin/validator_test.go
@@ -118,8 +118,6 @@ func TestMatchIssue(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
This is no longer required as of Go 1.22+
